### PR TITLE
Linux support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,11 +21,22 @@ jobs:
           python-version: '3.8'
       - name: Install Conan
         run: |
-          pip install bincrafters_package_tools
+          pip install conan
           conan user
+      - name: Install libsecret and other dependencies
+        # Only libsecret is required for building the package. However, the test-package needs an
+        # actual keyring.
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsecret-1-dev dbus-x11 dbus gnome-keyring libgnome-keyring-dev
       - name: Run
         run: |
-          python build.py
+            # steps required to setup the keyring
+            export DISPLAY=:99.0
+            eval $(dbus-launch --sh-syntax)
+            echo '$(whoami)' | gnome-keyring-daemon -r -d --unlock
+            # build the package and test-package
+            conan create . keychain/1.1@ --build missing
 
   Clang:
     runs-on: ubuntu-18.04
@@ -42,8 +53,19 @@ jobs:
           python-version: '3.8'
       - name: Install Conan
         run: |
-          pip install bincrafters_package_tools
+          pip install conan
           conan user
+      - name: Install libsecret and other dependencies
+        # Only libsecret is required for building the package. However, the test-package needs an
+        # actual keyring.
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsecret-1-dev dbus-x11 dbus gnome-keyring libgnome-keyring-dev
       - name: Run
         run: |
-          python build.py
+            # steps required to setup the keyring
+            export DISPLAY=:99.0
+            eval $(dbus-launch --sh-syntax)
+            echo '$(whoami)' | gnome-keyring-daemon -r -d --unlock
+            # build the package and test-package
+            conan create . keychain/1.1@ --build missing

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,8 +5,8 @@ class KeychainConan(ConanFile):
     name = "keychain"
     description = "A cross-platform wrapper for the operating system's credential storage"
     topics = ("conan", "security", "keychain")
-    # url = "https://github.com/bincrafters/conan-libname"
-    homepage = "https://github.com/reneme/keychain"
+    url = "https://github.com/reneme/conan-keychain"
+    homepage = "https://github.com/hrantzsch/keychain"
     license = "MIT"
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,7 +18,6 @@ class KeychainConan(ConanFile):
     _build_subfolder = "build_subfolder"
 
     def requirements(self):
-        pass
         # Note: keychain requires 'libsecret-1' on Linux which is not in Conan. libsecret must
         # therefore be installed on the system manually.
         # It further requires `glib-2.0` (via libsecret), which is in Conan. However, we cannot use
@@ -26,6 +25,10 @@ class KeychainConan(ConanFile):
         # For both of these dependencies, keychain relies on pkgconfig in order to find them. Once
         # both of the dependencies are available in Conan, we can use `pkg-config_installer` to find
         # them via pkgconfig.
+        #
+        # check if pkgconfig can find the dependencies
+        tools.PkgConfig("libsecret-1")
+        tools.PkgConfig("glib-2.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,14 +17,15 @@ class KeychainConan(ConanFile):
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
 
-    def build_requirements(self):
-        if self.settings.os == "Linux":
-            self.build_requires("pkg-config_installer/0.29.2@bincrafters/stable")
-
     def requirements(self):
-        if self.settings.os == "Linux":
-            self.requires("glib/2.58.3@bincrafters/stable")
-            # TODO: keychain also requires 'libsecret-1' which is not in conan
+        pass
+        # Note: keychain requires 'libsecret-1' on Linux which is not in Conan. libsecret must
+        # therefore be installed on the system manually.
+        # It further requires `glib-2.0` (via libsecret), which is in Conan. However, we cannot use
+        # it as it might be incompatible with the system-installed version of libsecret.
+        # For both of these dependencies, keychain relies on pkgconfig in order to find them. Once
+        # both of the dependencies are available in Conan, we can use `pkg-config_installer` to find
+        # them via pkgconfig.
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -55,3 +56,5 @@ class KeychainConan(ConanFile):
             self.cpp_info.frameworks = ['Security', 'CoreFoundation']
         if self.settings.os == "Windows":
             self.cpp_info.system_libs = ['Crypt32']
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs = ["secret-1", "glib-2.0"]


### PR DESCRIPTION
This PR re-instantiates Linux support.

Unfortunately we need to rely on both libsecret and glib to be installed manually on the system (glib is a dependency of libsecret anyway).

It is possible to install glib via Conan and have it found using the `pkg-config_installer` package. It is also possible to allow the Conan build to find the system-wide installed libsecret, e.g. by configuring `PKG_CONFIG_PATH` ([see here](https://docs.conan.io/en/latest/integrations/build_system/pkg_config_pc_files.html)). Alas, the system's libsecret version will likely be incompatible with the Conan-installed version of glib.
We resort to requiring manual installation of both dependencies.

In addition, the `url` and `homepage` field are adjusted to correspond to the conan conventions and the 'linux' workflow is fixed, though in a somewhat inconvenient manner.